### PR TITLE
Replacing callback with actual example instead of index

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-include README.rst LICENSE
+include README.md LICENSE

--- a/README.md
+++ b/README.md
@@ -153,10 +153,10 @@ Code:
         for label in shortLabels:
             indf[label] = None
 
-        def updateRow(ix, selectedLabels):
-            print(ix, selectedLabels)
+        def updateRow(title, selectedLabels):
+            print(title, selectedLabels)
             labs = setLabels([labels.index(y) for y in selectedLabels], len(labels))
-            indf.loc[indf.index.min()+ix, shortLabels] = labs
+            indf.loc[indf.title == title, shortLabels] = labs
 
         def finalProcessing(annotations):
             if out.exists():

--- a/pigeonXT/annotate.py
+++ b/pigeonXT/annotate.py
@@ -80,7 +80,7 @@ def annotate(examples,
 
     def add_annotation(annotation):
         annotations.append((examples[current_index], annotation))
-        if example_process_fn is not None and current_index > 0:
+        if example_process_fn is not None:
             example_process_fn(examples[current_index], annotations[-1][1])
         show_next()
 

--- a/pigeonXT/annotate.py
+++ b/pigeonXT/annotate.py
@@ -66,8 +66,6 @@ def annotate(examples,
     def show_next():
         nonlocal current_index
         current_index += 1
-        if example_process_fn is not None and current_index > 0:
-            example_process_fn(current_index - 1, annotations[-1][1])
         set_label_text()
         if current_index >= len(examples):
             for btn in buttons:
@@ -82,6 +80,8 @@ def annotate(examples,
 
     def add_annotation(annotation):
         annotations.append((examples[current_index], annotation))
+        if example_process_fn is not None and current_index > 0:
+            example_process_fn(examples[current_index], annotations[-1][1])
         show_next()
 
     def skip(btn):

--- a/pigeonXT_Examples.ipynb
+++ b/pigeonXT_Examples.ipynb
@@ -81,7 +81,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -90,9 +90,46 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "output_type": "display_data",
+     "data": {
+      "text/plain": "HTML(value='0 examples annotated, 3 examples left')",
+      "application/vnd.jupyter.widget-view+json": {
+       "version_major": 2,
+       "version_minor": 0,
+       "model_id": "79a6227a3ac74b369f1477d1b2113736"
+      }
+     },
+     "metadata": {}
+    },
+    {
+     "output_type": "display_data",
+     "data": {
+      "text/plain": "HBox(children=(Button(description='positive', style=ButtonStyle()), Button(description='negative', style=Butto…",
+      "application/vnd.jupyter.widget-view+json": {
+       "version_major": 2,
+       "version_minor": 0,
+       "model_id": "889b7b3fde594df1ae8e4d3fbb3ba2f3"
+      }
+     },
+     "metadata": {}
+    },
+    {
+     "output_type": "display_data",
+     "data": {
+      "text/plain": "Output()",
+      "application/vnd.jupyter.widget-view+json": {
+       "version_major": 2,
+       "version_minor": 0,
+       "model_id": "3bc7f236ab794144b7d97ba7d10fa294"
+      }
+     },
+     "metadata": {}
+    }
+   ],
    "source": [
     "annotations = annotate(\n",
     "  ['I love this movie', 'I was really disappointed by the book'],\n",
@@ -102,9 +139,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": "[('I love this movie', 'inbetween'),\n ('I was really disappointed by the book', 'inbetween')]"
+     },
+     "metadata": {},
+     "execution_count": 4
+    }
+   ],
    "source": [
     "annotations"
    ]
@@ -132,7 +178,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -142,7 +188,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -159,9 +205,46 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "output_type": "display_data",
+     "data": {
+      "text/plain": "HTML(value='0 examples annotated, 6 examples left')",
+      "application/vnd.jupyter.widget-view+json": {
+       "version_major": 2,
+       "version_minor": 0,
+       "model_id": "c8104b67c00c4d6197606fd1ec8f43cd"
+      }
+     },
+     "metadata": {}
+    },
+    {
+     "output_type": "display_data",
+     "data": {
+      "text/plain": "VBox(children=(HBox(children=(ToggleButton(value=False, description='Adventure'), ToggleButton(value=False, de…",
+      "application/vnd.jupyter.widget-view+json": {
+       "version_major": 2,
+       "version_minor": 0,
+       "model_id": "164c0caa57a04917aae3c3febc6bdf60"
+      }
+     },
+     "metadata": {}
+    },
+    {
+     "output_type": "display_data",
+     "data": {
+      "text/plain": "Output()",
+      "application/vnd.jupyter.widget-view+json": {
+       "version_major": 2,
+       "version_minor": 0,
+       "model_id": "bd4c83c605564bdc987897a0ab46d67b"
+      }
+     },
+     "metadata": {}
+    }
+   ],
    "source": [
     "annotations = annotate( df.title, \n",
     "                      options=labels, \n",
@@ -173,9 +256,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": "[('Star wars', ['Horror', 'Thriller']),\n ('The Positively True Adventures of the Alleged Texas Cheerleader-Murdering Mom',\n  ['Science fiction', 'Horror'])]"
+     },
+     "metadata": {},
+     "execution_count": 8
+    }
+   ],
    "source": [
     "annotations"
    ]
@@ -321,10 +413,10 @@
     "    for label in shortLabels:\n",
     "        indf[label] = None\n",
     "    \n",
-    "    def updateRow(ix, selectedLabels):\n",
-    "        print(ix, selectedLabels)\n",
+    "    def updateRow(title, selectedLabels):\n",
+    "        print(title, selectedLabels)\n",
     "        labs = setLabels([labels.index(y) for y in selectedLabels], len(labels))\n",
-    "        indf.loc[indf.index.min()+ix, shortLabels] = labs\n",
+    "        indf.loc[indf.title == title, shortLabels] = labs\n",
     "    \n",
     "    def finalProcessing(annotations):\n",
     "        if out.exists():\n",


### PR DESCRIPTION
Currently `example_process_fn` passes index of example and annotations. This makes callback function also dependent on list of examples that were sent to the annotate function. However the dependency can be broken if the example_process_fn is called with the full example and annotation. Also this is more closer to how we the final result is sent. 

